### PR TITLE
TL-289 add app env and apikey to simplefingerprint

### DIFF
--- a/app/models/fingerprints/simplistic_fingerprint.rb
+++ b/app/models/fingerprints/simplistic_fingerprint.rb
@@ -8,6 +8,8 @@ class SimplisticFingerprint < Fingerprint
     {
       :location        => location,
       :error_class     => notice.error_class.to_s,
+      :environment     => notice.server_environment[:"environment-name"],
+      :api_key         => @api_key
     }
   end
 


### PR DESCRIPTION
@tony-spataro-rs , @CallumD : I was able to reproduce locally the bad grouping error executing "rake airbrake:test" in two different apps, then, after these changes in this PR, errbit stopped grouping them.
I'm merging to release branch since I've seen this is the actual branch being used in errbit staging.

Tony suggested adding the app id or api_key and Callum the application environment, I think it's good to have both.
 
Remember! @tony-spataro-rs suggested "Once we fix the algorithm, we'll probably want to run the re-fingerprinting Rake task to ensure that everything is properly filed"