### PR TITLE
Tl 424 fix slack integration

### DIFF
--- a/app/models/notification_services/slack_service.rb
+++ b/app/models/notification_services/slack_service.rb
@@ -18,7 +18,47 @@ class NotificationServices::SlackService < NotificationService
   end
 
   def post_payload(problem)
-    {:text => message_for_slack(problem) }.to_json
+    {
+      :attachments => [
+        {
+           :fallback => message_for_slack(problem),
+           :pretext => "<#{problem_url(problem)}|Errbit - #{problem.app.name}: #{problem.error_class}>",
+           :color => "#D00000",
+           :fields => [
+              {
+                 :title => "Environment",
+                 :value => problem.environment,
+                 :short => false
+              },
+              {
+                 :title => "Location",
+                 :value => problem.where,
+                 :short => false
+              },
+              {
+                 :title => "Message",
+                 :value => problem.message.to_s,
+                 :short => false
+              },
+              {
+                 :title => "First Noticed",
+                 :value => problem.first_notice_at,
+                 :short => false
+              },
+              {
+                 :title => "Last Noticed",
+                 :value => problem.last_notice_at,
+                 :short => false
+              },
+              {
+                 :title => "Times Occurred",
+                 :value => problem.notices_count,
+                 :short => false
+              }
+           ]
+        }
+      ]
+    }.to_json
   end
 
   def create_notification(problem)

--- a/app/models/notification_services/slack_service.rb
+++ b/app/models/notification_services/slack_service.rb
@@ -24,4 +24,8 @@ class NotificationServices::SlackService < NotificationService
   def create_notification(problem)
     HTTParty.post(service_url, :body => post_payload(problem), :headers => { 'Content-Type' => 'application/json' })
   end
+
+  def configured?
+    service_url.present?
+  end
 end

--- a/app/models/notification_services/slack_service.rb
+++ b/app/models/notification_services/slack_service.rb
@@ -52,7 +52,7 @@ class NotificationServices::SlackService < NotificationService
               },
               {
                  :title => "Times Occurred",
-                 :value => problem.notices_count,
+                 :value => problem.notices_count.to_s,
                  :short => false
               }
            ]


### PR DESCRIPTION
Enric, this is the only code missing to make the Slack integration work (and, as a plus, make it more informative). I've verified it locally and it works.
Notice that, again, it only modifies the code of the file related to the Slack integration, so it's pretty safe.
